### PR TITLE
DSG-1626: Enable Cloud Trace / OpenTelemetry sampling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Here are the key configuration parameters for the application:
 - TOKEN_PRIVATE_KEY_SECRET: `<token-private-key-secret-name>`
 - TOKEN_PRIVATE_KEY_VERSION: `<token-private-key-secret-version>`
 - TOKEN_ISSUER: `<token-issuer-name>`
+- OTEL_SAMPLER_PROBABILITY: `<opentelemetry-sampler-probability>`
 
 ### Gradle
 

--- a/helm/application/values.demo.yaml
+++ b/helm/application/values.demo.yaml
@@ -80,3 +80,4 @@ env:
   SEND_GRID_EMAIL_ENDPOINT: "mail/send"
   SEND_GRID_API_KEY: "${sm://projects/dsgov-demo/secrets/dsgov-sendgrid-api-key/versions/latest}"
   SEND_GRID_SENDER: "${sm://projects/dsgov-demo/secrets/dsgov-sendgrid-sender-email/versions/latest}"
+  OTEL_SAMPLER_PROBABILITY: 1.0 # valid values: [0.0 - 1.0]

--- a/helm/application/values.dev.yaml
+++ b/helm/application/values.dev.yaml
@@ -79,3 +79,4 @@ env:
   SEND_GRID_EMAIL_ENDPOINT: "mail/send"
   SEND_GRID_API_KEY: "${sm://projects/dsgov-dev/secrets/dsgov-sendgrid-api-key/versions/latest}"
   SEND_GRID_SENDER: "${sm://projects/dsgov-dev/secrets/dsgov-sendgrid-sender-email/versions/latest}"
+  OTEL_SAMPLER_PROBABILITY: 1.0 # valid values: [0.0 - 1.0]

--- a/helm/application/values.local.yaml
+++ b/helm/application/values.local.yaml
@@ -91,3 +91,4 @@ env:
   SEND_GRID_EMAIL_ENDPOINT: "mail/send"
   SEND_GRID_API_KEY: "${sm://projects/dsgov-dev/secrets/dsgov-sendgrid-api-key/versions/latest}"
   SEND_GRID_SENDER: "${sm://projects/dsgov-dev/secrets/dsgov-sendgrid-sender-email/versions/latest}"
+  OTEL_SAMPLER_PROBABILITY: 1.0 # valid values: [0.0 - 1.0]

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -72,6 +72,8 @@ dependencies {
 	implementation 'com.twilio.sdk:twilio:9.9.1'
 	testImplementation 'org.mockito:mockito-inline:4.5.1'
 
+	//cloud trace
+	implementation 'com.google.cloud:spring-cloud-gcp-starter-trace:2.0.11'
 }
 
 test {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -4,6 +4,9 @@ server:
   forward-headers-strategy: framework
 
 spring:
+  sleuth:
+    sampler:
+      probability: ${OTEL_SAMPLER_PROBABILITY:1.0} # Valid values [0.0 - 1.0]
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_CONNECTION_URL}


### PR DESCRIPTION
## Description
- Add the [Spring Cloud Trace plugin.](https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/trace.html)
- Enable reconfigurability of the OpenTelemetry sampler probability using the Helm chart values.

## Motivation and Context
- Provide a means to view request tracing in GCP.
- Adjust sampling as needed in each environment.

## Areas for Focus

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
Patch
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (documentation only, will not require redeployment)
- [ ] Refactor or cleanup (functionality unchanged)
Minor
- [X] New feature (non-breaking change which adds functionality)
Major
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

- [X] I have confirmed all acceptance criteria defined by the story have been met