### PR TITLE
DSG-2082/re-enable sonarqube scanning and gating

### DIFF
--- a/.ci/cloudbuild-pull-request.yaml
+++ b/.ci/cloudbuild-pull-request.yaml
@@ -3,21 +3,48 @@ logsBucket: "gs://${_ARTIFACT_BUCKET_NAME}/cloudbuild-logs/app-${_SERVICE_NAME}-
 options:
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - id: 'Gradle Build && Publish to SonarQube'
-    name: 'openjdk:11'
+  - id: 'Gradle Build && Set up ssh tunnel && Publish to SonarQube'
+    secretEnv: ['SONARQUBE_TOKEN']
+    #name: 'gcr.io/cloud-builders/gcloud'
+    name: 'us-east4-docker.pkg.dev/dsgov-services/builders/cloudbuild-jdk17'
     entrypoint: bash
     args:
-      - "-c"
+      - '-c'
       - |
-        #./gradlew \
-        #-Dsonar.login="$$SONARQUBE_TOKEN" \
-        #  -Dsonar.projectKey=${REPO_NAME} \
-        #  -Dsonar.projectName=${REPO_NAME} \
-        #  -Dsonar.branch.name=${BRANCH_NAME} \
-        #  -Dsonar.host.url=${_SONARQUBE_HOST} \
-        #  -Dsonar.qualitygate.wait=true \
-        ./gradlew clean build
-    secretEnv: ['SONARQUBE_TOKEN']
+        SONAR_HOST=$(gcloud compute instances list --filter 'name~sonarqube' --format 'value(name)')
+        SONAR_ZONE=$(gcloud compute instances list --filter 'name~sonarqube' --format 'value(zone)')
+        gcloud compute ssh sonarqube@$$SONAR_HOST --zone $$SONAR_ZONE
+        gcloud compute ssh sonarqube@$$SONAR_HOST  \
+          --zone $$SONAR_ZONE \
+          --tunnel-through-iap \
+          --project $PROJECT_ID \
+          -- -NL 9000:localhost:9000 &
+        PID=$?
+        ELAPSED=0
+        TIMEOUT=10
+        echo "Establishing tunnel..."
+        until curl -s http://localhost:9000
+          do
+          sleep 1
+          if (( ELAPSED > TIMEOUT ))
+            then
+            echo "establishing tunnel timed out. exiting."
+            kill $$PID
+            exit 1
+          fi
+          ELAPSED=$(( ELAPSED + 1 ))
+        done
+        echo "Tunnel has been established"
+        ./gradlew \
+            -Dsonar.login="$$SONARQUBE_TOKEN" \
+            -Dsonar.projectKey=${REPO_NAME} \
+            -Dsonar.projectName=${REPO_NAME} \
+            -Dsonar.host.url=http://localhost:9000 \
+            -Dsonar.branch.name=${BRANCH_NAME} \
+            -Dsonar.qualitygate.wait=true \
+             clean build jacocoTestReport sonar
+
+        kill $$PID
 
   - id: 'Skaffold Render - Minikube'
     name: "${_GAR_BUILDER_URL}/helm"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


<!--- Give a summary of the change. -->
This change enables sonarqube publishing over an ssh tunnel and re-enables quality gating

<!-- insert jira markdown link with title -->
[___Sonarqube servers are out of compliance___](//[jira_url](https://dol-ewf.atlassian.net/browse/DSG-2082))

## Motivation and Context

<!--- Sonarqube was out of security compliance as single-factor sign-on was in place on a public interface. IAP has been put in place, meaning CI needs another path to sonarqube. This change enables an ssh tunnel over which to publish the scan reports, and re-enables quality gates -->

## Areas for Focus

It might make sense to review this together, please pull in @cbouscal if needed

## How Has This Been Tested?

This change has been tested repeatedly and successfully on dsgov-audit-service. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Patch

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (documentation only, will not require redeployment)
- [x] Refactor or cleanup (functionality unchanged)
  Minor
- [ ] New feature (non-breaking change which adds functionality)
  Major
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any do not apply, leave a description indicating why -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

- [x] I have confirmed all acceptance criteria defined by the story have been met.