### PR TITLE
Cloud-deploy: Update deploy release name [DSG-2213]

### DIFF
--- a/.ci/cloudbuild-push-request.yaml
+++ b/.ci/cloudbuild-push-request.yaml
@@ -62,7 +62,7 @@ steps:
     args:
       - "-c"
       - |
-        gcloud deploy releases create "${REPO_NAME}--${SHORT_SHA}" \
+        gcloud deploy releases create "$(echo ${REPO_NAME} | cut -d- -f2-)-${SHORT_SHA}" \
           --project=$PROJECT_ID \
           --region=${_DEPLOY_REGION} \
           --delivery-pipeline=${REPO_NAME} \


### PR DESCRIPTION
Following our mock engagement deployments, we encountered issues with cloud-deploy release names exceeding the maximum number of characters. This PR updates the release name's format by taking off the project prefix i.e. `dsgov` in order to avoid such issues moving forward; as this repository is used to scaffold/bootstrap potential client engagement repositories.

Sample Error encountered:
```
Created Cloud Deploy release devstream-document-management-2cdb55b.
Creating rollout projects/devstream-shared-services-4179/locations/us-east4/deliveryPipelines/devstream-document-management/releases/devstream-document-management-2cdb55b/rollouts/devstream-document-management-2cdb55b-to-devstream-dev-cluster-0001 in target devstream-dev-cluster
ERROR: (gcloud.deploy.releases.create) INVALID_ARGUMENT: resource ids must be lower-case letters, numbers, and hyphens, with the first character a letter, the last a letter or a number, and a 63 character maximum
```

Jira: https://dol-ewf.atlassian.net/browse/DSG-2213