### PR TITLE
add check for sonarqube exit status to cancel build on failed scan

### DIFF
--- a/.ci/cloudbuild-pull-request.yaml
+++ b/.ci/cloudbuild-pull-request.yaml
@@ -44,7 +44,15 @@ steps:
             -Dsonar.qualitygate.wait=true \
              clean build jacocoTestReport sonar
 
+        SQEXIT=$?
+        echo "Sonarqube scan exited with status code $$SQEXIT"
+    
         kill $$PID
+        ## Fail code needs to be the last step in the ID.
+        ## Moving an escape check to the end of the ID.
+        if [[ $$SQEXIT > 0 ]]; then
+          exit 1
+        fi
 
   - id: 'Skaffold Render - Minikube'
     name: "${_GAR_BUILDER_URL}/helm:4.0.0"


### PR DESCRIPTION
## Description

Update ci exit status for failed sonarqube check

[add check for sonarqube exit status to cancel build on failed scan](//https://dol-ewf.atlassian.net/browse/DSG-2254)

## Motivation and Context

Currently a sonarqube gate failure does *not* fail the build as expected/desired. This resolves that problem. 

## How Has This Been Tested?

This has been tested and validated against the dsgov-web repo ci build

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (documentation only, will not require redeployment)
- [ ] Refactor or cleanup (functionality unchanged)
  Minor
- [ ] New feature (non-breaking change which adds functionality)
  Major
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
