### PR TITLE
fix cloudbuild exit status

### DIFF
--- a/.ci/cloudbuild-pull-request.yaml
+++ b/.ci/cloudbuild-pull-request.yaml
@@ -44,7 +44,17 @@ steps:
             -Dsonar.qualitygate.wait=true \
              clean build jacocoTestReport sonar
 
+        EXIT=$?
+        echo "Build exited with status code $$EXIT"
+    
         kill $$PID
+    
+        ## Fail code needs to be the last step in the ID.
+        ## Moving an escape check to the end of the ID.
+    
+        if [[ $$EXIT > 0 ]]; then
+          exit 1
+        fi
 
   - id: 'Skaffold Render - Minikube'
     name: "${_GAR_BUILDER_URL}/helm:4.0.0"

--- a/.ci/cloudbuild-push-request.yaml
+++ b/.ci/cloudbuild-push-request.yaml
@@ -46,7 +46,17 @@ steps:
             -Dsonar.branch.name=${BRANCH_NAME} \
              clean build jacocoTestReport sonar
 
+        EXIT=$?
+        echo "Build exited with status code $$EXIT"
+    
         kill $$PID
+    
+        ## Fail code needs to be the last step in the ID.
+        ## Moving an escape check to the end of the ID.
+    
+        if [[ $$EXIT > 0 ]]; then
+          exit 1
+        fi
 
   - id: 'build'
     name: "${_GAR_BUILDER_URL}/helm:4.0.0"


### PR DESCRIPTION
## Description
Cloudbuilds fail when exit status is `0`. Need to add a status check and feed that to exit status. 

<!-- insert jira markdown link with title -->
[___Cloud build checks for PRs are passing when code build is failing___](//https://dol-ewf.atlassian.net/browse/DSG-2316)

## Motivation and Context

This solves the problem of failed builds passing their checks

## How Has This Been Tested?

Tested on dsgov-web repo successfully

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (documentation only, will not require redeployment)
- [ ] Refactor or cleanup (functionality unchanged)
  Minor
- [ ] New feature (non-breaking change which adds functionality)
  Major
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
