### PR TITLE
notify changed files on push to main

### DIFF
--- a/.github/scripts/notify_on_file_change.py
+++ b/.github/scripts/notify_on_file_change.py
@@ -1,0 +1,35 @@
+import requests
+import os
+import json
+
+
+def extract_modified_files(event_path):
+    with open(os.environ['GITHUB_EVENT_PATH']) as file:
+        event_data = json.load(file)
+    
+    ##  Pull request events have a different structure than push events.
+    if 'pull_request' in event_data:
+        url = event_data['pull_request']['diff_url']
+    else:
+        url = event_data['compare']
+    
+    return url
+
+def send_slack_notification(webhook_url, repository, url):
+    message = f"One or more monitored files has changed in repository `{repository}`.\n\nThe changed files can be seen here: {url}"
+    payload = {
+        "text": message,
+    }
+    requests.post(webhook_url, json=payload)
+
+if __name__ == "__main__":
+    webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    filename = os.environ.get("GITHUB_EVENT_PATH")
+    
+    url = extract_modified_files(filename)
+
+    if webhook_url and repository and filename:
+        send_slack_notification(webhook_url, repository, url)
+    else:
+        print("Missing environment variables. Unable to send notification.")

--- a/.github/workflows/file-change-notification.yaml
+++ b/.github/workflows/file-change-notification.yaml
@@ -1,0 +1,24 @@
+name: File Change Notification
+
+on:
+  push:
+    paths:
+      - 'skaffold.yaml'
+      - 'helm/application/values.demo.yaml'
+      - 'helm/application/values.dev.yaml'
+      - 'helm/application/values.local.yaml'
+    branches:    
+      - main
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Notify on File Change
+      run: python .github/scripts/notify_on_file_change.py
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.DSGOV_SLACK_WEBHOOK }}


### PR DESCRIPTION
In order to keep our engagement accelerator templates updated, we need to know when changes are made to helm and skaffold files. This change adds:

1. A github action (workflow) to CI that looks for modified helm and skaffold files
2. A python script to send notifications to slack when a file modification is trapped